### PR TITLE
Add option to squash the event vertices at the end to (0,0,0,0).

### DIFF
--- a/cpp/abconv/ArgumentProcessor.cc
+++ b/cpp/abconv/ArgumentProcessor.cc
@@ -16,6 +16,7 @@ UserArguments ArgumentProcessor::Process(int argc, char **argv)
     std::vector<std::string> optAllFiles;
     std::string preset="0";
     bool ab_off = false;
+    bool squash_vtx = false;
     bool plot_off = false;
     bool check_ca = false;
     ulong process_limit = 0;
@@ -34,6 +35,7 @@ UserArguments ArgumentProcessor::Process(int argc, char **argv)
     app.add_option("-l, --limit", process_limit, "Limit number of events to process. (Shutdown after this number of parsed events).");
 
     app.add_flag("--ab-off", ab_off, "No afterburner is applied");
+    app.add_flag("--squash-vtx", squash_vtx, "Squash all event vertices at the end to (0,0,0,0).");
     app.add_flag("--plot-off", plot_off, "Don't produce validation plots");
     app.add_flag("--exit-ca", check_ca, "Check existing crossing angle and exit if CA>1mrad");
     app.set_version_flag("-v, --version", "0.1.1");
@@ -73,6 +75,7 @@ UserArguments ArgumentProcessor::Process(int argc, char **argv)
 
     // Does afterburner off at all?
     result.AfterburnerEnabled = !ab_off;
+    result.SquashVertex = squash_vtx;
 
     // Limit on number of processed events
     result.EventProcessLimit = process_limit;

--- a/cpp/abconv/ArgumentProcessor.hh
+++ b/cpp/abconv/ArgumentProcessor.hh
@@ -35,6 +35,7 @@ struct UserArguments
     std::string OutputHistFileName;       /// Exact file name for histograms file
     bool PlottingEnabled;                 /// Don't produce validation plots
     bool AfterburnerEnabled;              /// Switch off afterburner
+    bool SquashVertex;                    /// Squash event vertices to (0,0,0,0)
     ulong EventProcessLimit;              /// Limit on processed events. Will shut down after this number of events processed
 
     long StartEventIndex;                 /// Start event index (all skipped before that)

--- a/cpp/abconv/Converter.cc
+++ b/cpp/abconv/Converter.cc
@@ -110,7 +110,9 @@ void ab::abconv::Converter::convert() {
 
             // Translate
             auto vtx = ab_result.vertex;
-            evt.shift_position_to(FourVector(vtx.x(), vtx.y(), vtx.z(), vtx.t()));
+            if( ! _afterburner->config().squash_vertex ) {
+              evt.shift_position_to(FourVector(vtx.x(), vtx.y(), vtx.z(), vtx.t()));
+            }
             if(_verbose) {
                 std::cout << "************\nAFTER TRANSLATION\n************\n";
                 Print::content(evt);

--- a/cpp/abconv/main.cc
+++ b/cpp/abconv/main.cc
@@ -61,6 +61,8 @@ int main(int argc, char** argv)
 
         // Check how to configure the afterburner
         auto ab_config = ab::convert::ConfigProvider::from_user_args(arg);
+        ab_config.squash_vertex = arg.SquashVertex; // squash config option
+
         afterburner->set_config(ab_config);
     } else {
         std::cout<<"Afterburner is DISABLED\n";

--- a/cpp/afterburner/Afterburner.cc
+++ b/cpp/afterburner/Afterburner.cc
@@ -462,6 +462,7 @@ void ab::Afterburner::print() const {
 
     cout << "Vertex distribution function: " << smear_func_to_str(_cfg.vertex_smear_func) << endl;
     cout << "Vertex simulation is: " << (_cfg.use_beam_bunch_sim ? string("on") : std::string("off")) << endl;
+    cout << "Vertex squashing at end is: " << (_cfg.squash_vertex ? string("on") : string("off")) << endl;
     cout << "Hadron beam:\n";
     cout << "   rms emittance   : hor = " << _cfg.hadron_beam.rms_emittance_hor << ", ver = " << _cfg.hadron_beam.rms_emittance_ver << endl;
     cout << "   beta star       : hor = " << _cfg.hadron_beam.beta_star_hor << ", ver = " << _cfg.hadron_beam.beta_star_ver << endl;

--- a/cpp/afterburner/AfterburnerConfig.hh
+++ b/cpp/afterburner/AfterburnerConfig.hh
@@ -51,6 +51,7 @@ namespace ab {
          * */
         SmearFuncs vertex_smear_func = SmearFuncs::Gauss;
 
+        bool squash_vertex = false;
         /** Smearing width (be it Gauss or Flat)
          *  (!) These fields relevant only if use_beam_bunch_sim = FALSE
          * */


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Add option to squash the event vertices at the end to (0,0,0,0).
It does so at the very end, thereby insuring that the crabbing transformation is unaffected.
This option will be useful for some far-bwd luminosity studies where we want the beam effects, but for convenience, we want every event placed at the same location in a far-bwd location.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
