### PR TITLE
Fix hepmc3 root output extension

### DIFF
--- a/cpp/abconv/ArgumentProcessor.cc
+++ b/cpp/abconv/ArgumentProcessor.cc
@@ -27,7 +27,7 @@ UserArguments ArgumentProcessor::Process(int argc, char **argv)
     app.add_option("-o, --output", output_base_name, "Base name for Output files ((!) no extension)");
     app.add_option("-p, --preset", preset, "0: IP6 High divergence[default], 1: IP6 High acceptance, 2: IP6 eAu; 3: IP8 Hight divergence..., More - see below");
     app.add_option("-i, --in-format", input_format, "Input format: auto [default], hepmc2, hepmc3, hpe, lhef, gz, treeroot, root");
-    app.add_option("-f, --out-format", output_format, "Output format: hepmc3 [default], treeroot, root, hepmc2, dot, none (no events file is saved)");
+    app.add_option("-f, --out-format", output_format, "Output format: hepmc3, treeroot [default], root, hepmc2, dot, none (no events file is saved)");
 
     app.add_option("-s, --ev-start", ev_start, "Start event index (all previous are skipped)");
     app.add_option("-e, --ev-end", ev_end, "End event index (end processing after this event)");


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Currently the `treeroot` setting saves the output file as `hepmc.root`. The extension `ddsim` expects for hepmc root files is `hepmc3.tree.root`.

At the moment people are either saving as the default hepmc ascii format and converting or it is possible to just rename the file after producing. Both are somewhat unnecessary steps.

This now changes the default output to the treeroot format

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
Adjust the file names from their scripts
### Does this PR change default behavior?
Outputs the hepmc root format with the extension expected by ddsim.