### PR TITLE
Correctly break rather than continue once max events reached

### DIFF
--- a/cpp/abconv/Converter.cc
+++ b/cpp/abconv/Converter.cc
@@ -35,7 +35,7 @@ void ab::abconv::Converter::convert() {
         }
         if (evt.event_number() < _first_event_number) continue;
 
-        if (_last_event_number && evt.event_number() > _last_event_number) continue;
+        if (_last_event_number && evt.event_number() > _last_event_number) break;
 
         if(0 == events_processed) {
             // The first event, determine beams configuration


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Stops the afterburner from running over all of the events/event limit when a last event number is set.
Separated from https://github.com/eic/afterburner/pull/7

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
Breaks the event loop early