### PR TITLE
Add missing eAu 10x100 GeV setting and 5 ePb settings

### DIFF
--- a/cpp/afterburner/EicConfigurator.cc
+++ b/cpp/afterburner/EicConfigurator.cc
@@ -317,7 +317,7 @@ ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_eau_110x10() {
     return cfg;
 }
 
-ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_eau_110x10() {
+ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_eau_100x10() {
 
     //Same settings as for e+Au 10x110 GeV/n - no official numbers exist
     //update numbers when available

--- a/cpp/afterburner/EicConfigurator.cc
+++ b/cpp/afterburner/EicConfigurator.cc
@@ -246,7 +246,7 @@ ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_ep_250x10() {
 }
 
 
-ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_eau_110x18() {
+ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_eAu_110x18() {
     ab::AfterburnerConfig cfg;
 
     // Crossing angle
@@ -282,7 +282,7 @@ ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_eau_110x18() {
 }
 
 
-ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_eau_110x10() {
+ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_eAu_110x10() {
     ab::AfterburnerConfig cfg;
 
     // Crossing angle
@@ -317,7 +317,7 @@ ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_eau_110x10() {
     return cfg;
 }
 
-ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_eau_100x10() {
+ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_eAu_100x10() {
 
     //Same settings as for e+Au 10x110 GeV/n - no official numbers exist
     //update numbers when available
@@ -358,7 +358,7 @@ ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_eau_100x10() {
     return cfg;
 }
 
-ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_eau_110x5() {
+ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_eAu_110x5() {
     ab::AfterburnerConfig cfg;
 
     // Crossing angle
@@ -394,7 +394,7 @@ ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_eau_110x5() {
 }
 
 
-ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_eau_41x5() {
+ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_eAu_41x5() {
     ab::AfterburnerConfig cfg;
 
     // Crossing angle
@@ -432,7 +432,7 @@ ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_eau_41x5() {
 //Add Pb ion configs here -- identical to the equivalent Au energies
 //since official numbers do not exist from the machine
 
-ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_epb_110x18() {
+ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_ePb_110x18() {
     ab::AfterburnerConfig cfg;
 
     // Crossing angle
@@ -468,7 +468,7 @@ ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_epb_110x18() {
 }
 
 
-ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_epb_110x10() {
+ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_ePb_110x10() {
     ab::AfterburnerConfig cfg;
 
     // Crossing angle
@@ -503,7 +503,7 @@ ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_epb_110x10() {
     return cfg;
 }
 
-ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_epb_100x10() {
+ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_ePb_100x10() {
 
     //Same settings as for e+Au 10x110 GeV/n - no official numbers exist
     //update numbers when available
@@ -544,7 +544,7 @@ ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_epb_100x10() {
     return cfg;
 }
 
-ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_epb_110x5() {
+ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_ePb_110x5() {
     ab::AfterburnerConfig cfg;
 
     // Crossing angle
@@ -580,7 +580,7 @@ ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_epb_110x5() {
 }
 
 
-ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_epb_41x5() {
+ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_ePb_41x5() {
     ab::AfterburnerConfig cfg;
 
     // Crossing angle
@@ -1533,10 +1533,10 @@ ab::AfterburnerConfig ab::EicConfigurator::config(ab::EicBeamEnergies ion, ab::E
     }
 
     if(beam_preset == EicBeamPresets::Ip6ElectronAurum) {
-        if(ion == EicBeamEnergies::E110GeV && electron == EicBeamEnergies::E18GeV) return preset_ip6_eau_110x18();
-        if(ion == EicBeamEnergies::E110GeV && electron == EicBeamEnergies::E10GeV) return preset_ip6_eau_110x10();
-        if(ion == EicBeamEnergies::E110GeV && electron == EicBeamEnergies::E5GeV)  return preset_ip6_eau_110x5();
-        if(ion == EicBeamEnergies::E41GeV  && electron == EicBeamEnergies::E5GeV)  return preset_ip6_eau_41x5();
+        if(ion == EicBeamEnergies::E110GeV && electron == EicBeamEnergies::E18GeV) return preset_ip6_eAu_110x18();
+        if(ion == EicBeamEnergies::E110GeV && electron == EicBeamEnergies::E10GeV) return preset_ip6_eAu_110x10();
+        if(ion == EicBeamEnergies::E110GeV && electron == EicBeamEnergies::E5GeV)  return preset_ip6_eAu_110x5();
+        if(ion == EicBeamEnergies::E41GeV  && electron == EicBeamEnergies::E5GeV)  return preset_ip6_eAu_41x5();
     }
 
     // High Divergence setting
@@ -1579,11 +1579,16 @@ ab::AfterburnerConfig ab::EicConfigurator::from_string(const std::string &name) 
     if(name == "ip6_eD_130x10")    return preset_ip6_eD_130x10();
     if(name == "ip6_ep_130x10")    return preset_ip6_ep_130x10();
     if(name == "ip6_ep_250x10")    return preset_ip6_ep_250x10();
-    if(name == "ip6_eau_110x18")   return preset_ip6_eau_110x18();
-    if(name == "ip6_eau_110x10")   return preset_ip6_eau_110x10();
-    if(name == "ip6_eau_100x10")   return preset_ip6_eau_100x10();
-    if(name == "ip6_eau_110x5")    return preset_ip6_eau_110x5();
-    if(name == "ip6_eau_41x5")     return preset_ip6_eau_41x5();
+    if(name == "ip6_eAu_110x18")   return preset_ip6_eAu_110x18();
+    if(name == "ip6_eAu_110x10")   return preset_ip6_eAu_110x10();
+    if(name == "ip6_eAu_100x10")   return preset_ip6_eAu_100x10();
+    if(name == "ip6_eAu_110x5")    return preset_ip6_eAu_110x5();
+    if(name == "ip6_eAu_41x5")     return preset_ip6_eAu_41x5();
+    if(name == "ip6_ePb_110x18")   return preset_ip6_ePb_110x18();
+    if(name == "ip6_ePb_110x10")   return preset_ip6_ePb_110x10();
+    if(name == "ip6_ePb_100x10")   return preset_ip6_ePb_100x10();
+    if(name == "ip6_ePb_110x5")    return preset_ip6_ePb_110x5();
+    if(name == "ip6_ePb_41x5")     return preset_ip6_ePb_41x5();
     if(name == "ip6_hiacc_41x5")   return preset_ip6_hiacc_41x5();
     if(name == "ip6_hiacc_100x5")  return preset_ip6_hiacc_100x5();
     if(name == "ip6_hiacc_100x10") return preset_ip6_hiacc_100x10();

--- a/cpp/afterburner/EicConfigurator.cc
+++ b/cpp/afterburner/EicConfigurator.cc
@@ -317,6 +317,46 @@ ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_eau_110x10() {
     return cfg;
 }
 
+ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_eau_110x10() {
+
+    //Same settings as for e+Au 10x110 GeV/n - no official numbers exist
+    //update numbers when available
+    //Note: these settings assume BeAGLE-like input, where the beam ion is
+    //      is the active nucleon in the interaction.    
+
+    ab::AfterburnerConfig cfg;
+
+    // Crossing angle
+    cfg.crossing_angle_hor = 25e-3;          // Crossing angle in horizontal plane [rad]
+    cfg.crossing_angle_ver = 100e-6;         // Crossing angle in vertical plane [rad]
+
+    cfg.ion_beam.beta_crab_hor = 500000.0;
+    cfg.electron_beam.beta_crab_hor = 150000.0;
+
+    // Beam divergence
+    cfg.ion_beam.divergence_hor = 216e-6;
+    cfg.ion_beam.divergence_ver = 274e-6;
+    cfg.electron_beam.divergence_hor = 102e-6;
+    cfg.electron_beam.divergence_ver = 92e-6;
+
+    // Beam beta star [mm] [mm]
+    cfg.ion_beam.beta_star_hor = 910;
+    cfg.ion_beam.beta_star_ver = 40;
+    cfg.electron_beam.beta_star_hor = 1930;
+    cfg.electron_beam.beta_star_ver = 120;
+
+    // RMS emittance
+    cfg.ion_beam.rms_emittance_hor = 42.3 * nm;
+    cfg.ion_beam.rms_emittance_ver = 3 * nm;
+    cfg.electron_beam.rms_emittance_hor = 20 * nm;
+    cfg.electron_beam.rms_emittance_ver = 1  * nm;
+
+    // RMS bunch length
+    cfg.ion_beam.rms_bunch_length = 7 * cm;
+    cfg.electron_beam.rms_bunch_length = 0.7 * cm;
+
+    return cfg;
+}
 
 ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_eau_110x5() {
     ab::AfterburnerConfig cfg;
@@ -1355,6 +1395,7 @@ ab::AfterburnerConfig ab::EicConfigurator::from_string(const std::string &name) 
     if(name == "ip6_ep_250x10")    return preset_ip6_ep_250x10();
     if(name == "ip6_eau_110x18")   return preset_ip6_eau_110x18();
     if(name == "ip6_eau_110x10")   return preset_ip6_eau_110x10();
+    if(name == "ip6_eau_100x10")   return preset_ip6_eau_100x10();
     if(name == "ip6_eau_110x5")    return preset_ip6_eau_110x5();
     if(name == "ip6_eau_41x5")     return preset_ip6_eau_41x5();
     if(name == "ip6_hiacc_41x5")   return preset_ip6_hiacc_41x5();

--- a/cpp/afterburner/EicConfigurator.cc
+++ b/cpp/afterburner/EicConfigurator.cc
@@ -429,6 +429,192 @@ ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_eau_41x5() {
     return cfg;
 }
 
+//Add Pb ion configs here -- identical to the equivalent Au energies
+//since official numbers do not exist from the machine
+
+ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_epb_110x18() {
+    ab::AfterburnerConfig cfg;
+
+    // Crossing angle
+    cfg.crossing_angle_hor = 25e-3;          // Crossing angle in horizontal plane [rad]
+    cfg.crossing_angle_ver = 100e-6;         // Crossing angle in vertical plane [rad]
+
+    cfg.ion_beam.beta_crab_hor = 500000.0;
+    cfg.electron_beam.beta_crab_hor = 150000.0;
+
+    // Beam divergence
+    cfg.ion_beam.divergence_hor = 218e-6;
+    cfg.ion_beam.divergence_ver = 379e-6;
+    cfg.electron_beam.divergence_hor = 101e-6;
+    cfg.electron_beam.divergence_ver = 37e-6;
+
+    // Beam beta star [mm]
+    cfg.ion_beam.beta_star_hor = 910;
+    cfg.ion_beam.beta_star_ver = 40;
+    cfg.electron_beam.beta_star_hor = 1960;
+    cfg.electron_beam.beta_star_ver = 410;
+
+    // RMS emittance
+    cfg.ion_beam.rms_emittance_hor = 43.2 * nm;
+    cfg.ion_beam.rms_emittance_ver = 5.8 * nm;
+    cfg.electron_beam.rms_emittance_hor = 20 * nm;
+    cfg.electron_beam.rms_emittance_ver = 0.6 * nm;
+
+    // RMS bunch length
+    cfg.ion_beam.rms_bunch_length = 7 * cm;
+    cfg.electron_beam.rms_bunch_length = 0.9 * cm;
+
+    return cfg;
+}
+
+
+ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_epb_110x10() {
+    ab::AfterburnerConfig cfg;
+
+    // Crossing angle
+    cfg.crossing_angle_hor = 25e-3;          // Crossing angle in horizontal plane [rad]
+    cfg.crossing_angle_ver = 100e-6;         // Crossing angle in vertical plane [rad]
+
+    cfg.ion_beam.beta_crab_hor = 500000.0;
+    cfg.electron_beam.beta_crab_hor = 150000.0;
+
+    // Beam divergence
+    cfg.ion_beam.divergence_hor = 216e-6;
+    cfg.ion_beam.divergence_ver = 274e-6;
+    cfg.electron_beam.divergence_hor = 102e-6;
+    cfg.electron_beam.divergence_ver = 92e-6;
+
+    // Beam beta star [mm] [mm]
+    cfg.ion_beam.beta_star_hor = 910;
+    cfg.ion_beam.beta_star_ver = 40;
+    cfg.electron_beam.beta_star_hor = 1930;
+    cfg.electron_beam.beta_star_ver = 120;
+
+    // RMS emittance
+    cfg.ion_beam.rms_emittance_hor = 42.3 * nm;
+    cfg.ion_beam.rms_emittance_ver = 3 * nm;
+    cfg.electron_beam.rms_emittance_hor = 20 * nm;
+    cfg.electron_beam.rms_emittance_ver = 1  * nm;
+
+    // RMS bunch length
+    cfg.ion_beam.rms_bunch_length = 7 * cm;
+    cfg.electron_beam.rms_bunch_length = 0.7 * cm;
+
+    return cfg;
+}
+
+ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_epb_100x10() {
+
+    //Same settings as for e+Au 10x110 GeV/n - no official numbers exist
+    //update numbers when available
+    //Note: these settings assume BeAGLE-like input, where the beam ion is
+    //      is the active nucleon in the interaction.    
+
+    ab::AfterburnerConfig cfg;
+
+    // Crossing angle
+    cfg.crossing_angle_hor = 25e-3;          // Crossing angle in horizontal plane [rad]
+    cfg.crossing_angle_ver = 100e-6;         // Crossing angle in vertical plane [rad]
+
+    cfg.ion_beam.beta_crab_hor = 500000.0;
+    cfg.electron_beam.beta_crab_hor = 150000.0;
+
+    // Beam divergence
+    cfg.ion_beam.divergence_hor = 216e-6;
+    cfg.ion_beam.divergence_ver = 274e-6;
+    cfg.electron_beam.divergence_hor = 102e-6;
+    cfg.electron_beam.divergence_ver = 92e-6;
+
+    // Beam beta star [mm] [mm]
+    cfg.ion_beam.beta_star_hor = 910;
+    cfg.ion_beam.beta_star_ver = 40;
+    cfg.electron_beam.beta_star_hor = 1930;
+    cfg.electron_beam.beta_star_ver = 120;
+
+    // RMS emittance
+    cfg.ion_beam.rms_emittance_hor = 42.3 * nm;
+    cfg.ion_beam.rms_emittance_ver = 3 * nm;
+    cfg.electron_beam.rms_emittance_hor = 20 * nm;
+    cfg.electron_beam.rms_emittance_ver = 1  * nm;
+
+    // RMS bunch length
+    cfg.ion_beam.rms_bunch_length = 7 * cm;
+    cfg.electron_beam.rms_bunch_length = 0.7 * cm;
+
+    return cfg;
+}
+
+ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_epb_110x5() {
+    ab::AfterburnerConfig cfg;
+
+    // Crossing angle
+    cfg.crossing_angle_hor = 25e-3;          // Crossing angle in horizontal plane [rad]
+    cfg.crossing_angle_ver = 100e-6;         // Crossing angle in vertical plane [rad]
+
+    cfg.ion_beam.beta_crab_hor = 500000.0;
+    cfg.electron_beam.beta_crab_hor = 150000.0;
+
+    // Beam divergence
+    cfg.ion_beam.divergence_hor = 215e-6;
+    cfg.ion_beam.divergence_ver = 275e-6;
+    cfg.electron_beam.divergence_hor = 102e-6;
+    cfg.electron_beam.divergence_ver = 185e-6;
+
+    // Beam beta star [mm]
+    cfg.ion_beam.beta_star_hor = 910;
+    cfg.ion_beam.beta_star_ver = 40;
+    cfg.electron_beam.beta_star_hor = 1930;
+    cfg.electron_beam.beta_star_ver = 60;
+
+    // RMS emittance
+    cfg.ion_beam.rms_emittance_hor = 42.3 * nm;
+    cfg.ion_beam.rms_emittance_ver = 3 * nm;
+    cfg.electron_beam.rms_emittance_hor = 20 * nm;
+    cfg.electron_beam.rms_emittance_ver = 2  * nm;
+
+    // RMS bunch length
+    cfg.ion_beam.rms_bunch_length = 7 * cm;
+    cfg.electron_beam.rms_bunch_length = 0.7 * cm;
+
+    return cfg;
+}
+
+
+ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_epb_41x5() {
+    ab::AfterburnerConfig cfg;
+
+    // Crossing angle
+    cfg.crossing_angle_hor = 25e-3;          // Crossing angle in horizontal plane [rad]
+    cfg.crossing_angle_ver = 100e-6;         // Crossing angle in vertical plane [rad]
+
+    //βcrabm1300/500/200beta function at crab cavity,
+    cfg.ion_beam.beta_crab_hor = 200000.0;
+    cfg.electron_beam.beta_crab_hor = 150000.0;
+
+    // Beam divergence
+    cfg.ion_beam.divergence_hor = 275e-6;
+    cfg.ion_beam.divergence_ver = 377e-6;
+    cfg.electron_beam.divergence_hor = 81e-6;
+    cfg.electron_beam.divergence_ver = 136e-6;
+
+    // Beam beta star [mm]
+    cfg.ion_beam.beta_star_hor = 900;
+    cfg.ion_beam.beta_star_ver = 40;
+    cfg.electron_beam.beta_star_hor = 3070;
+    cfg.electron_beam.beta_star_ver = 110;
+
+    // RMS emittance
+    cfg.ion_beam.rms_emittance_hor = 68.1 * nm;
+    cfg.ion_beam.rms_emittance_ver = 5.7 * nm;
+    cfg.electron_beam.rms_emittance_hor = 20 * nm;
+    cfg.electron_beam.rms_emittance_ver = 2 * nm;
+
+    // RMS bunch length
+    cfg.ion_beam.rms_bunch_length = 11.6 * cm;
+    cfg.electron_beam.rms_bunch_length = 0.7 * cm;
+    return cfg;
+}
+
 
 ab::AfterburnerConfig ab::EicConfigurator::preset_ip6_hiacc_41x5() {
     ab::AfterburnerConfig cfg;

--- a/cpp/afterburner/EicConfigurator.hh
+++ b/cpp/afterburner/EicConfigurator.hh
@@ -37,11 +37,17 @@ namespace ab {
         static AfterburnerConfig preset_ip6_ep_130x10(); //EIC early-science option -- only approximate for now
         static AfterburnerConfig preset_ip6_ep_250x10(); //EIC early-science option -- only approximate for now
         static AfterburnerConfig preset_ip6_eAu_100x10(); //EIC early-science option -- only approximate for now
+        static AfterburnerConfig preset_ip6_ePb_41x5();
+        static AfterburnerConfig preset_ip6_ePb_110x5();
+        static AfterburnerConfig preset_ip6_ePb_100x10();
+        static AfterburnerConfig preset_ip6_ePb_110x10();
+        static AfterburnerConfig preset_ip6_ePb_110x18();
 
-        static AfterburnerConfig preset_ip6_eau_41x5();
-        static AfterburnerConfig preset_ip6_eau_110x5();
-        static AfterburnerConfig preset_ip6_eau_110x10();
-        static AfterburnerConfig preset_ip6_eau_110x18();
+
+        static AfterburnerConfig preset_ip6_eAu_41x5();
+        static AfterburnerConfig preset_ip6_eAu_110x5();
+        static AfterburnerConfig preset_ip6_eAu_110x10();
+        static AfterburnerConfig preset_ip6_eAu_110x18();
         static AfterburnerConfig preset_ip6_hiacc_41x5();
         static AfterburnerConfig preset_ip6_hiacc_100x5();
         static AfterburnerConfig preset_ip6_hiacc_100x10();

--- a/cpp/afterburner/EicConfigurator.hh
+++ b/cpp/afterburner/EicConfigurator.hh
@@ -36,6 +36,7 @@ namespace ab {
         static AfterburnerConfig preset_ip6_eD_130x10(); //EIC early-science option -- only approximate for now
         static AfterburnerConfig preset_ip6_ep_130x10(); //EIC early-science option -- only approximate for now
         static AfterburnerConfig preset_ip6_ep_250x10(); //EIC early-science option -- only approximate for now
+        static AfterburnerConfig preset_ip6_eAu_100x10(); //EIC early-science option -- only approximate for now
 
         static AfterburnerConfig preset_ip6_eau_41x5();
         static AfterburnerConfig preset_ip6_eau_110x5();


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Adds missing afterburner configurations, but these are of course copies of similar beam energy/species configs in absence of official ones from the machine.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ x] Tests for the changes have been added
- [ x] Documentation has been added / updated
- [ x] Changes have been communicated to collaborators

Changes have been communicated to the requesting parties.

### Does this PR introduce breaking changes? What changes might users need to make to their code?

No.

### Does this PR change default behavior?

No, adds functionality.