### PR TITLE
changed first event skip logic to reader->skip, rather than looping o…

### DIFF
--- a/cpp/abconv/Converter.cc
+++ b/cpp/abconv/Converter.cc
@@ -38,7 +38,6 @@ void ab::abconv::Converter::convert() {
             printf("End of file reached. Events processed: %" PRIu64 " Exit.\n", events_processed);
             break;
         }
-        //if (evt.event_number() < _first_event_number) continue;
 
         if (_last_event_number && evt.event_number() > _last_event_number) break;
 

--- a/cpp/abconv/Converter.cc
+++ b/cpp/abconv/Converter.cc
@@ -25,7 +25,11 @@ void ab::abconv::Converter::convert() {
 
     uint64_t events_processed = 0;
     // HepMC files open
-
+    
+    if(_first_event_number > 0) {
+      _reader->skip(_first_event_number);
+    }
+    
     // Event loop
     while( !_reader->failed() ) {
         GenEvent evt;
@@ -34,7 +38,7 @@ void ab::abconv::Converter::convert() {
             printf("End of file reached. Events processed: %" PRIu64 " Exit.\n", events_processed);
             break;
         }
-        if (evt.event_number() < _first_event_number) continue;
+        //if (evt.event_number() < _first_event_number) continue;
 
         if (_last_event_number && evt.event_number() > _last_event_number) break;
 


### PR DESCRIPTION
…ver all GenEvt's with event number less than first_event

### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [ ] Medium
- [x ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #35 )
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.
Copilot was used to prepare graphs from the output of runtime tests of abconv with different "first event"
See below: Init timing for abconv is now flat, compared to O(N) increasing with first event number as report in issue35
<img width="1524" height="927" alt="Chart js-preview_after_fix" src="https://github.com/user-attachments/assets/c35c7ad7-4ea0-49de-abb5-2fd800e22bc8" />

./TestABConv.sh
========================================
START EVENT = 0
Sat Jul  4 09:26:02 PM BST 2026
Sat Jul  4 09:26:03 PM BST 2026
========================================
START EVENT = 10000000
Sat Jul  4 09:26:03 PM BST 2026
Sat Jul  4 09:26:05 PM BST 2026
========================================
START EVENT = 50000000
Sat Jul  4 09:26:05 PM BST 2026
Sat Jul  4 09:26:07 PM BST 2026
========================================
START EVENT = 100000000
Sat Jul  4 09:26:07 PM BST 2026
Sat Jul  4 09:26:08 PM BST 2026
========================================
START EVENT = 130000000
Sat Jul  4 09:26:08 PM BST 2026
Sat Jul  4 09:26:10 PM BST 2026
========================================
START EVENT = 150000000
Sat Jul  4 09:26:10 PM BST 2026
Sat Jul  4 09:26:11 PM BST 2026
